### PR TITLE
Save-load optimization

### DIFF
--- a/EpiphanyISelLowering.cpp
+++ b/EpiphanyISelLowering.cpp
@@ -515,10 +515,7 @@ void EpiphanyTargetLowering::EpiphanyCC::analyzeReturn(const SmallVectorImpl<Ty>
     MVT RegVT = this->getRegVT(VT, RetTy, CallNode, IsSoftFloat);
 
     if (Fn(I, VT, RegVT, CCValAssign::Full, Flags, this->CCInfo)) {
-#ifndef NDEBUG
-      dbgs() << "Call result #" << I << " has unhandled type "
-        << EVT(VT).getEVTString() << '\n';
-#endif
+      DEBUG(dbgs() << "Call result #" << I << " has unhandled type " << EVT(VT).getEVTString() << '\n');
       llvm_unreachable(nullptr);
     }
   }

--- a/EpiphanyInstrInfo.h
+++ b/EpiphanyInstrInfo.h
@@ -26,56 +26,73 @@
 
 namespace llvm {
 
-	class EpiphanyInstrInfo : public EpiphanyGenInstrInfo {
-		virtual void anchor();
-		protected:
-		const EpiphanySubtarget &Subtarget;
-		const EpiphanyRegisterInfo RI;
-		public:
-		explicit EpiphanyInstrInfo(const EpiphanySubtarget &STI);
+  class EpiphanyInstrInfo : public EpiphanyGenInstrInfo {
+    virtual void anchor();
+    protected:
+    const EpiphanySubtarget &Subtarget;
+    const EpiphanyRegisterInfo RI;
+    public:
+    explicit EpiphanyInstrInfo(const EpiphanySubtarget &STI);
 
-		static const EpiphanyInstrInfo *create(EpiphanySubtarget &STI);
+    static const EpiphanyInstrInfo *create(EpiphanySubtarget &STI);
 
-		/// getRegisterInfo - TargetInstrInfo is a superset of MRegister info.  As
-		/// such, whenever a client has an instance of instruction info, it should
-		/// always be able to get register info as well (through this method).
-		///
-		const EpiphanyRegisterInfo &getRegisterInfo() const;
+    /// getRegisterInfo - TargetInstrInfo is a superset of MRegister info.  As
+    /// such, whenever a client has an instance of instruction info, it should
+    /// always be able to get register info as well (through this method).
+    ///
+    const EpiphanyRegisterInfo &getRegisterInfo() const;
 
-		/// Return the number of bytes of code the specified instruction may be.
-		unsigned GetInstSizeInBytes(const MachineInstr &MI) const;
+    /// Return the number of bytes of code the specified instruction may be.
+    unsigned GetInstSizeInBytes(const MachineInstr &MI) const;
 
-		bool expandPostRAPseudo(MachineInstr &MI) const override;
+    bool expandPostRAPseudo(MachineInstr &MI) const override;
 
-		void adjustStackPtr(unsigned SP, int64_t Amount, MachineBasicBlock &MBB,
-				MachineBasicBlock::iterator I) const;
+    void adjustStackPtr(unsigned SP, int64_t Amount, MachineBasicBlock &MBB,
+        MachineBasicBlock::iterator I) const;
 
-		void storeRegToStackSlot(MachineBasicBlock &MBB, MachineBasicBlock::iterator MI,
-				unsigned SrcReg, bool KillSrc, int FrameIdx, const TargetRegisterClass *Rd,
-				const TargetRegisterInfo *TRI) const override;
+    /// isLoadFromStackSlot - If the specified machine instruction is a direct
+    /// load from a stack slot, return the virtual or physical register number of
+    /// the destination along with the FrameIndex of the loaded stack slot.  If
+    /// not, return 0.  This predicate must return 0 if the instruction has
+    /// any side effects other than loading from the stack slot.
+    unsigned isLoadFromStackSlot(const MachineInstr &MI,
+        int &FrameIndex) const override;
 
-		void loadRegFromStackSlot(MachineBasicBlock &MBB, MachineBasicBlock::iterator MI,
-				unsigned DestReg, int FrameIdx, const TargetRegisterClass *Rd,
-				const TargetRegisterInfo *TRI) const override;
+    /// isStoreToStackSlot - If the specified machine instruction is a direct
+    /// store to a stack slot, return the virtual or physical register number of
+    /// the source reg along with the FrameIndex of the loaded stack slot.  If
+    /// not, return 0.  This predicate must return 0 if the instruction has
+    /// any side effects other than storing to the stack slot.
+    unsigned isStoreToStackSlot(const MachineInstr &MI,
+        int &FrameIndex) const override;
 
-		void copyPhysReg(MachineBasicBlock &MBB, MachineBasicBlock::iterator MI,
-				const DebugLoc &DL, unsigned DestReg, unsigned SrcReg,
-				bool KillSrc) const override;
+    void storeRegToStackSlot(MachineBasicBlock &MBB, MachineBasicBlock::iterator MI,
+        unsigned SrcReg, bool KillSrc, int FrameIdx, const TargetRegisterClass *Rd,
+        const TargetRegisterInfo *TRI) const override;
 
-		// Branch analysis.
-		bool isUnpredicatedTerminator(const MachineInstr &MI) const override;
-		bool analyzeBranch(MachineBasicBlock &MBB, MachineBasicBlock *&TBB,
-				MachineBasicBlock *&FBB, SmallVectorImpl<MachineOperand> &Cond,
-				bool AllowModify) const override;
-		unsigned RemoveBranch(MachineBasicBlock &MBB) const override;
-		unsigned InsertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
-				MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
-				const DebugLoc &DL) const override;
+    void loadRegFromStackSlot(MachineBasicBlock &MBB, MachineBasicBlock::iterator MI,
+        unsigned DestReg, int FrameIdx, const TargetRegisterClass *Rd,
+        const TargetRegisterInfo *TRI) const override;
 
-		private:
-		void expandRTS(MachineBasicBlock &MBB, MachineBasicBlock::iterator I) const;
+    void copyPhysReg(MachineBasicBlock &MBB, MachineBasicBlock::iterator MI,
+        const DebugLoc &DL, unsigned DestReg, unsigned SrcReg,
+        bool KillSrc) const override;
 
-	};
+    // Branch analysis.
+    bool isUnpredicatedTerminator(const MachineInstr &MI) const override;
+    bool analyzeBranch(MachineBasicBlock &MBB, MachineBasicBlock *&TBB,
+        MachineBasicBlock *&FBB, SmallVectorImpl<MachineOperand> &Cond,
+        bool AllowModify) const override;
+    unsigned RemoveBranch(MachineBasicBlock &MBB) const override;
+    unsigned InsertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
+        MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
+        const DebugLoc &DL) const override;
+    bool ReverseBranchCondition(SmallVectorImpl<MachineOperand> &Cond) const override;
+
+    private:
+    void expandRTS(MachineBasicBlock &MBB, MachineBasicBlock::iterator I) const;
+
+  };
 
 } // End of namespace llvm
 #endif

--- a/EpiphanyInstrInfo.td
+++ b/EpiphanyInstrInfo.td
@@ -112,8 +112,8 @@ defm STRi8   : StoreM<AlignedStore<truncstorei8>,  LS_byte>;
 defm STRi16  : StoreM<AlignedStore<truncstorei16>, LS_hword>;
 defm STRi32  : StoreM<AlignedStore<store>,         LS_word>;
 
-def LDRf32   : Load16<0, FPR32, AlignedLoad<load>,    LS_word>;
-def STRf32   : Store16<0, FPR32, AlignedStore<store>, LS_word>;
+def LDRf32   : Load32<0, FPR32, AlignedLoad<load>,    LS_word>;
+def STRf32   : Store32<0, FPR32, AlignedStore<store>, LS_word>;
 
 //===----------------------------------------------------------------------===//
 // Arithmetic operations with registers

--- a/EpiphanySubtarget.h
+++ b/EpiphanySubtarget.h
@@ -93,6 +93,10 @@ public:
     return &InstrItins;
   }
 
+  AntiDepBreakMode getAntiDepBreakMode() const override { return ANTIDEP_ALL; }
+
+  bool enablePostRAScheduler() const override { return true; }
+
 };
 } // End llvm namespace
 

--- a/MCTargetDesc/EpiphanyAsmBackend.cpp
+++ b/MCTargetDesc/EpiphanyAsmBackend.cpp
@@ -46,9 +46,8 @@ static unsigned adjustFixupValue(const MCFixup &Fixup, uint64_t Value,
       // Shift by 7 as it will be shifted by 1 afterwards, See Arch reference
       // TODO: iPTR is 16 bits, that's why sign-extension is needed in such way
       DEBUG(dbgs() << "PCREL24 Value before adjust "; dbgs().write_hex(Value); dbgs() << "\n");
-      Value = (Value & 0x1ffffff) << 7;
+      Value = ((Value & 0xffffffff) << 7) & 0xffffffff;
       DEBUG(dbgs() << "PCREL24 Value after adjust "; dbgs().write_hex(Value); dbgs() << "\n");
-      Value = Value & 0xffffffff;
       break;
 		case FK_GPRel_4:
 		case FK_Data_4:
@@ -58,6 +57,7 @@ static unsigned adjustFixupValue(const MCFixup &Fixup, uint64_t Value,
 		case Epiphany::fixup_Epiphany_HI16:
 		case Epiphany::fixup_Epiphany_GOT:
 			// Get the higher 16-bits. Also add 1 if bit 15 is 1.
+      DEBUG(dbgs() << "HI16/GOT value before adjust "; dbgs().write_hex(Value); dbgs() << "\n");
 			Value = ((Value + 0x8000) >> 16) & 0xffff;
 			break;
 	}

--- a/MCTargetDesc/EpiphanyAsmBackend.cpp
+++ b/MCTargetDesc/EpiphanyAsmBackend.cpp
@@ -45,14 +45,14 @@ static unsigned adjustFixupValue(const MCFixup &Fixup, uint64_t Value,
       // Sign-extend and shift by 7 bits
       // Shift by 7 as it will be shifted by 1 afterwards, See Arch reference
       // TODO: iPTR is 16 bits, that's why sign-extension is needed in such way
-      DEBUG(dbgs() << "PCREL24 Value before adjust "; dbgs().write_hex(Value); dbgs() << "\n");
-      Value = ((Value & 0xffffffff) << 7) & 0xffffffff;
-      DEBUG(dbgs() << "PCREL24 Value after adjust "; dbgs().write_hex(Value); dbgs() << "\n");
+      //DEBUG(dbgs() << "PCREL24 Value before adjust "; dbgs().write_hex(Value); dbgs() << "\n");
+      //Value = ((Value & 0xffffffff) << 7) & 0xffffffff;
+      //DEBUG(dbgs() << "PCREL24 Value after adjust "; dbgs().write_hex(Value); dbgs() << "\n");
+      Value = Value << 7;
       break;
 		case FK_GPRel_4:
 		case FK_Data_4:
 		case Epiphany::fixup_Epiphany_LO16:
-      DEBUG(dbgs() << "FK_GPREL_4/Data4 value before adjust "; dbgs().write_hex(Value); dbgs() << "\n");
 			break;
 		case Epiphany::fixup_Epiphany_HI16:
 		case Epiphany::fixup_Epiphany_GOT:

--- a/MCTargetDesc/EpiphanyMCCodeEmitter.cpp
+++ b/MCTargetDesc/EpiphanyMCCodeEmitter.cpp
@@ -67,8 +67,8 @@ void EpiphanyMCCodeEmitter::encodeInstruction(const MCInst &MI, raw_ostream &OS,
   // Check for unimplemented opcodes.
   unsigned Opcode = MI.getOpcode();
   if (!Binary) {
-    dbgs() << "Opcode: " << Opcode << "\n";
-    dbgs() << "Binary: " << Binary << "\n";
+    DEBUG(dbgs() << "Opcode: " << Opcode << "\n");
+    DEBUG(dbgs() << "Binary: " << Binary << "\n");
     llvm_unreachable("unimplemented opcode in encodeInstruction()");
   }
 
@@ -119,7 +119,7 @@ unsigned EpiphanyMCCodeEmitter::getJumpTargetOpValue(const MCInst &MI, unsigned 
 
   // If destination is already resolved into immediate - nothing to do
   if (MO.isImm()) {
-    dbgs() << "\nFixup to immediate: " << MO.getImm() << "\n";
+    DEBUG(dbgs() << "\nFixup to immediate: " << MO.getImm() << "\n");
     return MO.getImm();
   }
 


### PR DESCRIPTION
Added AntiDepBreakMode to re-alloc regs when using (-O > 0)
Sometimes still hitting the same error on adjustFixup, no idea why.
Added a couple of functions that may be needed later.